### PR TITLE
Simplify handling of MISSING for EndpointDocument

### DIFF
--- a/src/globus_sdk/services/gcs/data/endpoint.py
+++ b/src/globus_sdk/services/gcs/data/endpoint.py
@@ -71,8 +71,6 @@ class EndpointDocument(utils.PayloadWrapper):
         ``network_use``.
     """
 
-    _MISSING_SENTINEL = MISSING
-
     DATATYPE_BASE = "endpoint"
     DATATYPE_VERSION_IMPLICATIONS: dict[str, tuple[int, int, int]] = {
         "gridftp_control_channel_port": (1, 1, 0),
@@ -119,43 +117,29 @@ class EndpointDocument(utils.PayloadWrapper):
         additional_fields: dict[str, t.Any] | MissingType = MISSING,
     ):
         super().__init__()
-        self._set_optstrs(
-            DATA_TYPE=data_type,
-            contact_email=contact_email,
-            contact_info=contact_info,
-            department=department,
-            description=description,
-            display_name=display_name,
-            info_link=info_link,
-            network_use=network_use,
-            organization=organization,
+        self["DATA_TYPE"] = data_type
+        self["contact_email"] = contact_email
+        self["contact_info"] = contact_info
+        self["department"] = department
+        self["description"] = description
+        self["display_name"] = display_name
+        self["info_link"] = info_link
+        self["network_use"] = network_use
+        self["organization"] = organization
+        self["keywords"] = (
+            keywords
+            if isinstance(keywords, MissingType)
+            else list(utils.safe_strseq_iter(keywords))
         )
-        self._set_optstrlists(
-            keywords=keywords,
-        )
-        self._set_optbools(
-            allow_udt=allow_udt,
-            public=public,
-        )
-        self._set_optints(
-            max_concurrency=max_concurrency,
-            max_parallelism=max_parallelism,
-            preferred_concurrency=preferred_concurrency,
-            preferred_parallelism=preferred_parallelism,
-        )
+        self["allow_udt"] = allow_udt
+        self["public"] = public
+        self["max_concurrency"] = max_concurrency
+        self["max_parallelism"] = max_parallelism
+        self["preferred_concurrency"] = preferred_concurrency
+        self["preferred_parallelism"] = preferred_parallelism
+        self["subscription_id"] = subscription_id
+        self["gridftp_control_channel_port"] = gridftp_control_channel_port
 
-        # self._set_opt<type>s() is not used for nullable types
-        self._set_value(
-            "subscription_id",
-            subscription_id,
-            callback=lambda v: str(v) if v is not None else None,
-        )
-        self._set_value(
-            "gridftp_control_channel_port",
-            gridftp_control_channel_port,
-            callback=lambda v: int(v) if v is not None else None,
-        )
-
-        if additional_fields is not MISSING:
+        if not isinstance(additional_fields, MissingType):
             self.update(additional_fields)
         ensure_datatype(self)

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -147,9 +147,6 @@ class PayloadWrapper(PayloadWrapperBase):
     # internal helpers for setting non-null values
     #
 
-    # Some payloads use None to represent "no value" and others use the MISSING sentinel
-    _MISSING_SENTINEL: None | MissingType = None
-
     def _set_value(
         self,
         key: str,
@@ -157,26 +154,25 @@ class PayloadWrapper(PayloadWrapperBase):
         callback: t.Callable[[t.Any], t.Any] | None = None,
     ) -> None:
         """
-        Internal helper for setting a value on the payload.
+        Internal helper for setting an omittable value on the payload.
 
-        If the value matches the class level _MISSING_SENTINEL (defaults to None),
-            it will be omitted from the payload.
+        If the value is non-None, it will be set and the callback (if provided) will be
+        invoked on it.
+        Otherwise, it will be ignored and the callback will not be invoked.
 
         :param key: The key to set.
         :param val: The value to set.
         :param callback: An optional callback to apply to the value immediately
             before it is set.
         """
-        if val is not self._MISSING_SENTINEL:
+        if val is not None:
             self[key] = callback(val) if callback else val
 
     def _set_optstrs(self, **kwargs: t.Any) -> None:
         """
         Convenience function for setting a collection of omittable string values.
 
-        Any values matching the class level _MISSING_SENTINEL (defaults to None) will
-          be omitted.
-        All values are passed through ``str()`` prior to assignment.
+        Values are converted to strings prior to assignment.
         """
         for k, v in kwargs.items():
             self._set_value(k, v, callback=str)
@@ -185,9 +181,7 @@ class PayloadWrapper(PayloadWrapperBase):
         """
         Convenience function for setting a collection of omittable string list values.
 
-        Any values matching the class level _MISSING_SENTINEL (defaults to None) will
-          be omitted.
-        For each list value, each element is converted to a string prior to assignment.
+        Values are converted to lists of strings prior to assignment.
         """
         for k, v in kwargs.items():
             self._set_value(k, v, callback=lambda x: list(safe_strseq_iter(x)))
@@ -196,9 +190,7 @@ class PayloadWrapper(PayloadWrapperBase):
         """
         Convenience function for setting a collection of omittable bool values.
 
-        Any values matching the class level _MISSING_SENTINEL (defaults to None) will
-          be omitted.
-        All values are passed through ``bool()`` prior to assignment.
+        Values are converted to bools prior to assignment.
         """
         for k, v in kwargs.items():
             self._set_value(k, v, callback=bool)
@@ -207,9 +199,7 @@ class PayloadWrapper(PayloadWrapperBase):
         """
         Convenience function for setting a collection of omittable int values.
 
-        Any values matching the class level _MISSING_SENTINEL (defaults to None) will
-          be omitted.
-        All values are passed through ``int()`` prior to assignment.
+        Values are converted to ints prior to assignment.
         """
         for k, v in kwargs.items():
             self._set_value(k, v, callback=int)


### PR DESCRIPTION
- Get rid of `_MISSING_SENTINEL`, revert the old helpers to `None`-only, but don't use them for this class
- Assign values directly, without worrying about applying converters in almost any cases
- In the one case in which a converter is needed (`keywords`), apply it explicitly inline

----

This is basically the direction I'd like to take things. It demonstrates a key benefit of `MISSING`, which is that values can be passthrough assigned without any need for a special case to cover omission (since omission is naturally expressed by MISSING itself).

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--1.org.readthedocs.build/en/1/

<!-- readthedocs-preview globus-sdk-python end -->